### PR TITLE
Move Caracas to -4

### DIFF
--- a/timezones.json
+++ b/timezones.json
@@ -45,7 +45,7 @@
     "America/Rio_Branco": "(GMT-05:00) Rio Branco",
     "America/Toronto": "(GMT-05:00) Eastern Time - Toronto",
     "Pacific/Easter": "(GMT-05:00) Easter Island",
-    "America/Caracas": "(GMT-04:30) Caracas",
+    "America/Caracas": "(GMT-04:00) Caracas",
     "America/Asuncion": "(GMT-03:00) Asuncion",
     "America/Barbados": "(GMT-04:00) Barbados",
     "America/Boa_Vista": "(GMT-04:00) Boa Vista",


### PR DESCRIPTION
https://github.com/home-assistant/frontend/issues/14205

> On 15 April 2016, President [Nicolás Maduro](https://en.wikipedia.org/wiki/Nicol%C3%A1s_Maduro) announced that Venezuela would reverse Chávez's time change due to the [shortage of electricity](https://en.wikipedia.org/wiki/Shortages_in_Venezuela) (the country's hydroelectric power has been hit by low water levels[[1]](https://en.wikipedia.org/wiki/Time_in_Venezuela#cite_note-vz-1)) in Venezuela, with a return to [UTC−04:00](https://en.wikipedia.org/wiki/UTC%E2%88%9204:00) which began on 1 May 2016 at 03:00:00.[[1]](https://en.wikipedia.org/wiki/Time_in_Venezuela#cite_note-vz-1)[[3]](https://en.wikipedia.org/wiki/Time_in_Venezuela#cite_note-3)